### PR TITLE
Expand site biography and research details

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,11 +1,38 @@
 ---
 permalink: /
-title: "RAO Fenggui"
+title: "Robbie Rao Fenggui"
 author_profile: true
 ---
 
-Hello! I am RAO Fenggui from Hong Kong Polytechnic University.
-My research interests include areas of computing and engineering.
-You can find my code on [GitHub](https://github.com/RobbieRao) and my publications through [ORCID](https://orcid.org/0009-0000-8990-1515).
+**Robbie Rao Fenggui**  
+AED Lab, School of Design, The Hong Kong Polytechnic University
 
-Feel free to contact me for collaboration.
+Interdisciplinary design researcher bridging art, technology, and human-centered innovation. Expert in ergonomic design, generative AI, and interactive systems.
+
+## Contact
+Hung Hom, Kowloon, Hong Kong  
+Tel: (852) 8403 2765  
+Email: [robbie.rao@connect.polyu.hk](mailto:robbie.rao@connect.polyu.hk)  
+Website: [robbierao.com](https://robbierao.com)  
+AED Lab: [sd.polyu.edu.hk/aedlab](https://sd.polyu.edu.hk/aedlab)  
+Design Anything Lab: [designanything.design](https://designanything.design)
+
+## Projects
+- **Blind Box Experience Upgrade** – Reimagined the blind box concept through innovative interaction design and patented solutions.
+- **AIGC-Driven Virtual Art Education Tutor** – Transformed virtual art education using generative AI, earning top honors.
+- **Private Domain UX Design** – Developed data-driven strategies and intuitive interfaces to enhance digital user engagement.
+
+## Publications & Patents
+- 2025: *The Immersive Art Therapy Driven by AIGC: An Innovative Approach to Alleviating Children’s Nyctophobia* – CHI SDC Paper.
+- 2024: *ContextCam: Bridging Context Awareness with Creative Human-AI Image Co-Creation* – CHI Full Paper. DOI: 10.1145/3613904.3642129.
+- 2024: *Enlivening Performance Art: Enhanced Interactivity through Embodied Cognition and Real-Time Physical Visualization on Swarm Tangible Interfaces* – Proceedings of the ICLC. DOI: 10.5281/zenodo.11350409.
+- 2023: *TrailTracking: AI-Driven Distributed Narratives of Descendant Civilizations in a Digitally Encoded Cosmos* – Science 24 hours. DOI: 10.3969/j.issn.1002-7394.2024.10.003.
+- 2023: *AI-Assisted Design Creation Software* – Software Monograph, Registration No. 2023SR1444677.
+- 2023: *Integrated Art Education Service Solution Based on Generative AI* – Invention Patent, Application No. 202310399782X.
+- 2022: *Box* – Design Patent, Patent No. ZL 2022 3 0178236.X.
+- 2022: *A Kind of Robotic Arm* – Utility Model Patent, Patent No. ZL 2022 2 0740933.4.
+- 2022: *Image Digital Projection Device* – Utility Model Patent, Patent No. ZL 2022 2 3454035.1.
+
+## Experience
+- **CEO**, Hangzhou BIZZLE Network Technology Co., Ltd. (Feb 2022 – Present) – Leading innovative product design and managing dynamic teams to cultivate market-leading strategies.
+- **Co-Founder**, DesignAnything Lab, China Academy of Art (Mar 2022 – Sep 2024) – Spearheaded tailored design solutions that enhance social impact.

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -5,4 +5,35 @@ permalink: /cv/
 author_profile: true
 ---
 
-A complete CV will be added soon. Please check back later.
+## Profile
+Interdisciplinary design researcher bridging art, technology, and human-centered innovation. Expertise in ergonomic design, generative AI, and interactive systems.
+
+## Education
+- **School of Design, The Hong Kong Polytechnic University** – AED Lab, Ph.D. Student, 2024–Present.
+- **China Academy of Art** – BFA in Innovative Design, 2020–2024.
+
+## Experience
+- **CEO**, Hangzhou BIZZLE Network Technology Co., Ltd. (Feb 2022 – Present).
+- **Co-Founder**, DesignAnything Lab, China Academy of Art (Mar 2022 – Sep 2024).
+
+## Projects
+- **Blind Box Experience Upgrade** – Reimagined the blind box concept through innovative interaction design and patented solutions.
+- **AIGC-Driven Virtual Art Education Tutor** – Transformed virtual art education using generative AI, earning top honors.
+- **Private Domain UX Design** – Developed data-driven strategies and intuitive interfaces to enhance digital user engagement.
+
+## Publications & Patents
+- *The Immersive Art Therapy Driven by AIGC: An Innovative Approach to Alleviating Children’s Nyctophobia*, CHI SDC Paper, 2025.
+- *ContextCam: Bridging Context Awareness with Creative Human-AI Image Co-Creation*, CHI Full Paper, 2024. DOI: 10.1145/3613904.3642129.
+- *Enlivening Performance Art: Enhanced Interactivity through Embodied Cognition and Real-Time Physical Visualization on Swarm Tangible Interfaces*, Proceedings of the ICLC, 2024. DOI: 10.5281/zenodo.11350409.
+- *TrailTracking: AI-Driven Distributed Narratives of Descendant Civilizations in a Digitally Encoded Cosmos*, Science 24 hours, 2024. DOI: 10.3969/j.issn.1002-7394.2024.10.003.
+- *AI-Assisted Design Creation Software*, Software Monograph, 2023. Registration No. 2023SR1444677.
+- *Integrated Art Education Service Solution Based on Generative AI*, Invention Patent, 2023. Application No. 202310399782X.
+- *Box*, Design Patent, 2022. Patent No. ZL 2022 3 0178236.X.
+- *A Kind of Robotic Arm*, Utility Model Patent, 2022. Patent No. ZL 2022 2 0740933.4.
+- *Image Digital Projection Device*, Utility Model Patent, 2022. Patent No. ZL 2022 2 3454035.1.
+
+## Contact
+Hung Hom, Kowloon, Hong Kong  
+Tel: (852) 8403 2765  
+Email: [robbie.rao@connect.polyu.hk](mailto:robbie.rao@connect.polyu.hk)  
+Website: [robbierao.com](https://robbierao.com)

--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -1,36 +1,23 @@
 ---
 layout: archive
-title: "Publications"
+title: "Publications & Patents"
 permalink: /publications/
 author_profile: true
 ---
 
-{% if site.author.googlescholar %}
-  <div class="wordwrap">You can also find my articles on <a href="{{site.author.googlescholar}}">my Google Scholar profile</a>.</div>
-{% endif %}
+<h2>Peer-Reviewed Papers</h2>
+<ul>
+  <li>2025: <em>The Immersive Art Therapy Driven by AIGC: An Innovative Approach to Alleviating Children’s Nyctophobia</em> – CHI SDC Paper.</li>
+  <li>2024: <em>ContextCam: Bridging Context Awareness with Creative Human-AI Image Co-Creation</em> – CHI Full Paper. DOI: 10.1145/3613904.3642129.</li>
+  <li>2024: <em>Enlivening Performance Art: Enhanced Interactivity through Embodied Cognition and Real-Time Physical Visualization on Swarm Tangible Interfaces</em> – Proceedings of the ICLC. DOI: 10.5281/zenodo.11350409.</li>
+  <li>2023: <em>TrailTracking: AI-Driven Distributed Narratives of Descendant Civilizations in a Digitally Encoded Cosmos</em> – Science 24 hours. DOI: 10.3969/j.issn.1002-7394.2024.10.003.</li>
+</ul>
 
-{% include base_path %}
-
-<!-- New style rendering if publication categories are defined -->
-{% if site.publication_category %}
-  {% for category in site.publication_category  %}
-    {% assign title_shown = false %}
-    {% for post in site.publications reversed %}
-      {% if post.category != category[0] %}
-        {% continue %}
-      {% endif %}
-      {% unless title_shown %}
-        <h2>{{ category[1].title }}</h2><hr />
-        {% assign title_shown = true %}
-      {% endunless %}
-      {% include archive-single.html %}
-    {% endfor %}
-  {% endfor %}
-{% else %}
-  {% for post in site.publications reversed %}
-    {% include archive-single.html %}
-  {% endfor %}
-{% endif %}
-
-
-
+<h2>Patents & Software</h2>
+<ul>
+  <li>2023: <em>AI-Assisted Design Creation Software</em> – Software Monograph, Registration No. 2023SR1444677.</li>
+  <li>2023: <em>Integrated Art Education Service Solution Based on Generative AI</em> – Invention Patent, Application No. 202310399782X.</li>
+  <li>2022: <em>Box</em> – Design Patent, Patent No. ZL 2022 3 0178236.X.</li>
+  <li>2022: <em>A Kind of Robotic Arm</em> – Utility Model Patent, Patent No. ZL 2022 2 0740933.4.</li>
+  <li>2022: <em>Image Digital Projection Device</em> – Utility Model Patent, Patent No. ZL 2022 2 3454035.1.</li>
+</ul>

--- a/_portfolio/aigc-driven-virtual-art-education-tutor.md
+++ b/_portfolio/aigc-driven-virtual-art-education-tutor.md
@@ -1,0 +1,9 @@
+---
+title: "AIGC-Driven Virtual Art Education Tutor"
+collection: portfolio
+permalink: /portfolio/aigc-driven-virtual-art-education-tutor/
+date: 2024-01-02
+excerpt: "Transformed virtual art education using generative AI, earning top honors."
+---
+
+Transformed virtual art education using generative AI, earning top honors.

--- a/_portfolio/blind-box-experience-upgrade.md
+++ b/_portfolio/blind-box-experience-upgrade.md
@@ -1,0 +1,9 @@
+---
+title: "Blind Box Experience Upgrade"
+collection: portfolio
+permalink: /portfolio/blind-box-experience-upgrade/
+date: 2024-01-01
+excerpt: "Reimagined the blind box concept through innovative interaction design and patented solutions."
+---
+
+Reimagined the blind box concept through innovative interaction design and patented solutions.

--- a/_portfolio/private-domain-ux-design.md
+++ b/_portfolio/private-domain-ux-design.md
@@ -1,0 +1,9 @@
+---
+title: "Private Domain UX Design"
+collection: portfolio
+permalink: /portfolio/private-domain-ux-design/
+date: 2024-01-03
+excerpt: "Developed data-driven strategies and intuitive interfaces to enhance digital user engagement."
+---
+
+Developed data-driven strategies and intuitive interfaces to enhance digital user engagement.


### PR DESCRIPTION
## Summary
- Enrich homepage with detailed bio, contact details, projects, publications & patents, and experience
- Add structured CV page covering education, work, projects, and research outputs
- Populate publications page and portfolio with key papers, patents, and project entries

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `npm run build:js`

------
https://chatgpt.com/codex/tasks/task_e_6890d6d23bfc832ea106e6bf612bd557