### PR TITLE
refactor: use page title in home heading

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ title: "Robbie Rao Fenggui"
 <div id="particles-js"></div>
 
 <section class="hero">
-  <h1>Robbie Rao Fenggui</h1>
+  <h1>{{ page.title }}</h1>
   <p>Interdisciplinary design researcher bridging art, technology, and human-centered innovation.</p>
 </section>
 


### PR DESCRIPTION
## Summary
- replace hard-coded name on landing page with liquid page.title reference

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_6890e0c498e4832eaa085bf1a4b12f62