### PR TITLE
Revamp homepage with 3D head and simplified navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -11,12 +11,6 @@ main:
   - title: "Publications"
     url: /publications/
 
-  - title: "Talks"
-    url: /talks/
-
-  - title: "Teaching"
-    url: /teaching/
-
   - title: "Portfolio"
     url: /portfolio/
 

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -12,6 +12,19 @@
   padding: 10rem 1rem 5rem;
 }
 
+.profile-photo {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  margin-bottom: 1rem;
+}
+
+#model-container {
+  width: 300px;
+  height: 300px;
+  margin: 2rem auto 0;
+}
+
 .tags {
   text-align: center;
 }

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -1,3 +1,37 @@
 document.addEventListener('DOMContentLoaded', function () {
   particlesJS.load('particles-js', '/assets/js/particles.json');
+
+  const container = document.getElementById('model-container');
+  if (container && window.THREE && window.THREE.OBJLoader) {
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, container.clientWidth / container.clientHeight, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ alpha: true });
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 1);
+    scene.add(ambient);
+
+    const loader = new THREE.OBJLoader();
+    loader.load('https://robbierao.com/model2.obj', function (object) {
+      object.traverse(function (child) {
+        if (child.isMesh) {
+          const geometry = child.geometry;
+          geometry.center();
+          const material = new THREE.PointsMaterial({ color: 0xffffff, size: 0.005 });
+          const points = new THREE.Points(geometry, material);
+          scene.add(points);
+        }
+      });
+      animate();
+    });
+
+    camera.position.z = 2.5;
+
+    function animate() {
+      requestAnimationFrame(animate);
+      scene.rotation.y += 0.01;
+      renderer.render(scene, camera);
+    }
+  }
 });

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 layout: single
-author_profile: true
-title: "Robbie Rao Fenggui"
+author_profile: false
+title: ""
 ---
 
 <link rel="stylesheet" href="/assets/css/home.css">
@@ -9,8 +9,10 @@ title: "Robbie Rao Fenggui"
 <div id="particles-js"></div>
 
 <section class="hero">
-  <h1>{{ page.title }}</h1>
+  <img src="https://robbierao.com/Robbie.png" alt="Robbie Rao" class="profile-photo">
+  <h1>Robbie Rao Fenggui</h1>
   <p>Interdisciplinary design researcher bridging art, technology, and human-centered innovation.</p>
+  <div id="model-container"></div>
 </section>
 
 <section class="tags">
@@ -21,8 +23,6 @@ title: "Robbie Rao Fenggui"
 
 <section class="links">
   <a class="link-box" href="/publications/">Publications</a>
-  <a class="link-box" href="/talks/">Talks</a>
-  <a class="link-box" href="/teaching/">Teaching</a>
   <a class="link-box" href="/portfolio/">Portfolio</a>
   <a class="link-box" href="/year-archive/">Blog Posts</a>
   <a class="link-box" href="/cv/">CV</a>
@@ -39,4 +39,6 @@ title: "Robbie Rao Fenggui"
 </section>
 
 <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/loaders/OBJLoader.js"></script>
 <script src="/assets/js/home.js"></script>


### PR DESCRIPTION
## Summary
- Streamline landing page by removing duplicate name headings and dropping Talks/Teaching links
- Add 3D head model viewer and portrait image for a more dynamic introduction
- Simplify navigation to core sections only

## Testing
- `npm run build:js`
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6890e7718a90832e80dbe63fb0f2ce91