### PR TITLE
Add cache-busting and no-cache headers

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,12 +10,15 @@
 <meta name="HandheldFriendly" content="True">
 <meta name="MobileOptimized" content="320">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
 
 <script>
   document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
+<link rel="stylesheet" href="{{ base_path }}/assets/css/main.css?v={{ site.time | date: '%Y%m%d%H%M%S' }}">
 
 <meta http-equiv="cleartype" content="on">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,3 +1,3 @@
-<script type="module" src="{{ base_path }}/assets/js/main.min.js"></script>
+<script type="module" src="{{ base_path }}/assets/js/main.min.js?v={{ site.time | date: '%Y%m%d%H%M%S' }}"></script>
 
 {% include analytics.html %}


### PR DESCRIPTION
## Summary
- Add no-cache HTTP meta tags
- Append timestamp query string to CSS and JS URLs to bust cache

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `npm test` *(fails: Missing script: "test")*
- `npm run build:js`


------
https://chatgpt.com/codex/tasks/task_e_689166d5cb64832eb3130fc154b6f6e8