### PR TITLE
Refactor homepage with terminal-style interface

### DIFF
--- a/_layouts/terminal.html
+++ b/_layouts/terminal.html
@@ -1,0 +1,17 @@
+---
+layout: compress
+---
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ page.title }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/assets/css/terminal.css">
+</head>
+<body>
+  {{ content }}
+  <script src="/assets/js/terminal.js"></script>
+</body>
+</html>

--- a/assets/css/terminal.css
+++ b/assets/css/terminal.css
@@ -1,0 +1,61 @@
+body {
+  font-family: "Fira Code", monospace;
+  background: #fff;
+  color: #000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 2rem;
+}
+
+.profile {
+  width: 150px;
+  border-radius: 50%;
+}
+
+h1 {
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.tagline {
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.tags {
+  margin-bottom: 1rem;
+}
+
+.tags button {
+  background: none;
+  border: none;
+  color: #555;
+  margin: 0 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.tags button:hover {
+  color: #000;
+}
+
+#terminal {
+  width: 100%;
+  max-width: 600px;
+  background: #000;
+  color: #0f0;
+  padding: 1rem;
+  font-size: 0.9rem;
+  min-height: 150px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+  white-space: pre-wrap;
+}
+
+#terminal .command {
+  color: #0f0;
+}
+
+#terminal .output {
+  color: #fff;
+}

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,0 +1,35 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const terminal = document.getElementById('terminal');
+  const buttons = document.querySelectorAll('.tags button');
+
+  function typeText(text, container) {
+    let index = 0;
+    function type() {
+      if (index < text.length) {
+        container.textContent += text.charAt(index);
+        index++;
+        setTimeout(type, 30);
+      }
+    }
+    type();
+  }
+
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const cmd = btn.dataset.cmd;
+      const content = btn.dataset.content;
+      terminal.innerHTML = '';
+
+      const commandLine = document.createElement('div');
+      commandLine.className = 'command';
+      commandLine.textContent = '> ' + cmd;
+      terminal.appendChild(commandLine);
+
+      const outputLine = document.createElement('div');
+      outputLine.className = 'output';
+      terminal.appendChild(outputLine);
+
+      typeText('\n' + content, outputLine);
+    });
+  });
+});

--- a/index.md
+++ b/index.md
@@ -1,32 +1,15 @@
 ---
-layout: single
-author_profile: true
+layout: terminal
 title: "Robbie Rao Fenggui"
 ---
 
-<link rel="stylesheet" href="/assets/css/home.css">
-
-<div id="particles-js"></div>
-
-<div id="head-container"></div>
-
-<section class="hero">
-  <p>Interdisciplinary design researcher bridging art, technology, and human-centered innovation.</p>
-</section>
-
-
-<section class="contact">
-  <h2>Contact</h2>
-  <p>School of Design, PolyU<br>
-     Hung Hom, Kowloon, Hong Kong<br>
-     Supervisor: Yan Tina Luximon<br>
-     Tel: (852) 84032765<br>
-     Email: <a href="mailto:robbie.rao@connect.polyu.hk">robbie.rao@connect.polyu.hk</a></p>
-  <p><a href="https://robbierao.com">robbierao.com</a> · <a href="https://sd.polyu.edu.hk/aedlab">AED Lab</a> · <a href="https://designanything.design">Design Anything Lab</a></p>
-</section>
-
-<script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/loaders/OBJLoader.js"></script>
-<script src="/assets/js/head.js"></script>
-<script src="/assets/js/home.js"></script>
+<div class="container">
+  <img src="/images/profile.png" alt="Profile photo" class="profile">
+  <h1>Robbie Rao Fenggui</h1>
+  <p class="tagline">Interdisciplinary design researcher bridging art, technology, and human-centered innovation.</p>
+  <div class="tags">
+    <button data-cmd="open contact" data-content="School of Design, PolyU\nHung Hom, Kowloon, Hong Kong\nSupervisor: Yan Tina Luximon\nTel: (852) 84032765\nEmail: robbie.rao@connect.polyu.hk">Contact</button>
+    <button data-cmd="open links" data-content="https://robbierao.com\nhttps://sd.polyu.edu.hk/aedlab\nhttps://designanything.design">Links</button>
+  </div>
+  <div id="terminal"></div>
+</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "academic-pages",
-  "version": "0.8.1.1",
+  "version": "0.8.1.2",
   "description": "Academic Pages Mistakes Jekyll theme npm build scripts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- redesign homepage with minimalist terminal aesthetic
- add JS to stream command output when tags clicked
- bump site version to 0.8.1.2

## Testing
- `npm run build:js`
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c634b7089c832e927b5a0573beb002