### PR TITLE
Refine terminal-style homepage with Mac aesthetics

### DIFF
--- a/_layouts/terminal.html
+++ b/_layouts/terminal.html
@@ -1,0 +1,17 @@
+---
+layout: compress
+---
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ page.title }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/assets/css/terminal.css">
+</head>
+<body>
+  {{ content }}
+  <script src="/assets/js/terminal.js"></script>
+</body>
+</html>

--- a/assets/css/terminal.css
+++ b/assets/css/terminal.css
@@ -1,0 +1,88 @@
+body {
+  font-family: "SF Mono", "Menlo", "Monaco", "Courier New", monospace;
+  background: #f5f5f7;
+  color: #333;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 2rem;
+}
+
+.profile {
+  width: 150px;
+  border-radius: 50%;
+}
+
+h1 {
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.tagline {
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.tags {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.tags button {
+  background: none;
+  border: none;
+  color: #555;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.tags button:hover {
+  color: #000;
+}
+
+.terminal-window {
+  width: 100%;
+  max-width: 600px;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 0 10px rgba(0,0,0,0.25);
+}
+
+.terminal-bar {
+  background: #e0e0e0;
+  padding: 0.25rem 0.5rem;
+  display: flex;
+  gap: 0.4rem;
+}
+
+.terminal-bar .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.terminal-bar .red { background: #ff5f56; }
+.terminal-bar .yellow { background: #ffbd2e; }
+.terminal-bar .green { background: #27c93f; }
+
+#terminal {
+  background: #000;
+  color: #0f0;
+  padding: 1rem;
+  font-size: 0.9rem;
+  min-height: 150px;
+  white-space: pre-wrap;
+}
+
+#terminal .command {
+  color: #0f0;
+}
+
+#terminal .output {
+  color: #fff;
+}
+

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const terminal = document.getElementById('terminal');
+  const buttons = document.querySelectorAll('.tags button');
+
+  function typeText(text, container) {
+    let index = 0;
+    function type() {
+      if (index < text.length) {
+        container.textContent += text.charAt(index);
+        index++;
+        setTimeout(type, 30);
+      }
+    }
+    type();
+  }
+
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const cmd = btn.dataset.cmd;
+      const content = btn.dataset.content.replace(/\\n/g, '\n');
+      terminal.innerHTML = '';
+
+      const commandLine = document.createElement('div');
+      commandLine.className = 'command';
+      commandLine.textContent = '> ' + cmd;
+      terminal.appendChild(commandLine);
+
+      const outputLine = document.createElement('div');
+      outputLine.className = 'output';
+      terminal.appendChild(outputLine);
+
+      typeText('\n' + content, outputLine);
+    });
+  });
+});
+

--- a/index.md
+++ b/index.md
@@ -1,32 +1,29 @@
 ---
-layout: single
-author_profile: true
+layout: terminal
 title: "Robbie Rao Fenggui"
 ---
 
-<link rel="stylesheet" href="/assets/css/home.css">
+<div class="container">
+  <img src="/images/profile.png" alt="Profile photo" class="profile">
+  <h1>Robbie Rao Fenggui</h1>
+  <p class="tagline">Interdisciplinary design researcher bridging art, technology, and human-centered innovation.</p>
+  <div class="tags">
+    <button data-cmd="open contact" data-content="School of Design, PolyU\\nHung Hom, Kowloon, Hong Kong\\nSupervisor: Yan Tina Luximon\\nTel: (852) 84032765\\nEmail: robbie.rao@connect.polyu.hk">Contact</button>
+    <button data-cmd="open links" data-content="https://robbierao.com\\nhttps://sd.polyu.edu.hk/aedlab\\nhttps://designanything.design">Links</button>
+    <button data-cmd="open education" data-content="School of Design, The Hong Kong Polytechnic University – AED Lab, Ph.D. Student, 2024–Present.\\nChina Academy of Art – B.Eng in Innovative Design, 2020–2024.">Education</button>
+    <button data-cmd="open publications" data-content="The Immersive Art Therapy Driven by AIGC: An Innovative Approach to Alleviating Children’s Nyctophobia, CHI EA 2025.\\nBetween Real and Imagined: Developing a dynamic immersive virtual auditing (DIVA) framework for high-density urban health trails, eCAADe 2025.\\nContextCam: Bridging Context Awareness with Creative Human-AI Image Co-Creation, CHI 2024.\\nEnlivening Performance Art: Enhanced Interactivity through Embodied Cognition and Real-Time Physical Visualization on Swarm Tangible Interfaces, ICLC 2024.\\nTrailTracking: AI-Driven Distributed Narratives of Descendant Civilizations in a Digitally Encoded Cosmos, Science 24 hours 2024.">Publications</button>
+    <button data-cmd="open patents" data-content="AI-Assisted Design Creation Software, Software Monograph, 2023.\\nIntegrated Art Education Service Solution Based on Generative AI, Invention Patent 2023.\\nBox, Design Patent 2022.\\nA Kind of Robotic Arm, Utility Model Patent 2022.\\nImage Digital Projection Device, Utility Model Patent 2022.">Patents</button>
+    <button data-cmd="open award" data-content="AIGC-Driven Virtual Art Education Tutor – top honors.">Award</button>
+    <button data-cmd="open projects" data-content="Blind Box Experience Upgrade – Reimagined the blind box concept through innovative interaction design.\\nAIGC-Driven Virtual Art Education Tutor – Transformed virtual art education using generative AI.\\nPrivate Domain UX Design – Developed data-driven strategies and intuitive interfaces to enhance digital user engagement.">Projects</button>
+    <button data-cmd="open experience" data-content="CEO, Hangzhou BIZZLE Network Technology Co., Ltd. (Feb 2022 – Present).\\nCo-Founder, DesignAnything Lab, China Academy of Art (Mar 2022 – Sep 2024).">Experience</button>
+  </div>
+  <div class="terminal-window">
+    <div class="terminal-bar">
+      <span class="dot red"></span>
+      <span class="dot yellow"></span>
+      <span class="dot green"></span>
+    </div>
+    <div id="terminal"></div>
+  </div>
+</div>
 
-<div id="particles-js"></div>
-
-<div id="head-container"></div>
-
-<section class="hero">
-  <p>Interdisciplinary design researcher bridging art, technology, and human-centered innovation.</p>
-</section>
-
-
-<section class="contact">
-  <h2>Contact</h2>
-  <p>School of Design, PolyU<br>
-     Hung Hom, Kowloon, Hong Kong<br>
-     Supervisor: Yan Tina Luximon<br>
-     Tel: (852) 84032765<br>
-     Email: <a href="mailto:robbie.rao@connect.polyu.hk">robbie.rao@connect.polyu.hk</a></p>
-  <p><a href="https://robbierao.com">robbierao.com</a> · <a href="https://sd.polyu.edu.hk/aedlab">AED Lab</a> · <a href="https://designanything.design">Design Anything Lab</a></p>
-</section>
-
-<script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/loaders/OBJLoader.js"></script>
-<script src="/assets/js/head.js"></script>
-<script src="/assets/js/home.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "academic-pages",
-  "version": "0.8.1.1",
+  "version": "0.8.1.3",
   "description": "Academic Pages Mistakes Jekyll theme npm build scripts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- restore tags for contact, education, projects, publications, and more
- apply Mac-inspired terminal styling and fix newline rendering
- bump site version to 0.8.1.3

## Testing
- `npm run build:js`
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c634b7089c832e927b5a0573beb002