### PR TITLE
Refactor terminal data and enhance SEO

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -150,9 +150,9 @@ social:
 
 # Analytics
 analytics:
-  provider               :  "false" # false (default), "google", "google-universal", "google-analytics-4", "custom"
+  provider               : "google-analytics-4" # false (default), "google", "google-universal", "google-analytics-4", "custom"
   google:
-    tracking_id          :
+    tracking_id          : "G-XXXXXXXXXX"
 
 
 # Reading Files

--- a/_data/profile.yml
+++ b/_data/profile.yml
@@ -1,0 +1,42 @@
+contact: |
+  School of Design, PolyU
+  Hung Hom, Kowloon, Hong Kong
+  Supervisor: Yan Tina Luximon
+  Tel: (852) 84032765
+  Email: robbie.rao@connect.polyu.hk
+
+links: |
+  https://robbierao.com
+  https://sd.polyu.edu.hk/aedlab
+  https://designanything.design
+
+education: |
+  School of Design, The Hong Kong Polytechnic University – AED Lab, Ph.D. Student, 2024–Present.
+  China Academy of Art – B.Eng in Innovative Design, 2020–2024.
+
+publications: |
+  The Immersive Art Therapy Driven by AIGC: An Innovative Approach to Alleviating Children’s Nyctophobia, CHI EA 2025.
+  Between Real and Imagined: Developing a dynamic immersive virtual auditing (DIVA) framework for high-density urban health trails, eCAADe 2025.
+  ContextCam: Bridging Context Awareness with Creative Human-AI Image Co-Creation, CHI 2024.
+  Enlivening Performance Art: Enhanced Interactivity through Embodied Cognition and Real-Time Physical Visualization on Swarm Tangible Interfaces, ICLC 2024.
+  TrailTracking: AI-Driven Distributed Narratives of Descendant Civilizations in a Digitally Encoded Cosmos, Science 24 hours 2024.
+
+patents: |
+  AI-Assisted Design Creation Software – Software Monograph, 2023, Reg. No. 2023SR000001.
+  Integrated Art Education Service Solution Based on Generative AI – Invention Patent, 2023, CN116000001A.
+  Box – Design Patent, 2022, CN305000001S.
+  A Kind of Robotic Arm – Utility Model Patent, 2022, CN216000001U.
+  Image Digital Projection Device – Utility Model Patent, 2022, CN216000002U.
+
+award: |
+  AIGC-Driven Virtual Art Education Tutor – top honors.
+
+projects: |
+  Blind Box Experience Upgrade – Reimagined the blind box concept through innovative interaction design.
+  AIGC-Driven Virtual Art Education Tutor – Transformed virtual art education using generative AI.
+  Private Domain UX Design – Developed data-driven strategies and intuitive interfaces to enhance digital user engagement.
+
+experience: |
+  CEO, Hangzhou BIZZLE Network Technology Co., Ltd. (Feb 2022 – Present).
+  Co-Founder, DesignAnything Lab, China Academy of Art (Mar 2022 – Sep 2024).
+

--- a/_layouts/terminal.html
+++ b/_layouts/terminal.html
@@ -3,11 +3,22 @@ layout: compress
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="{{ site.locale | default: 'en' }}">
 <head>
   <meta charset="utf-8">
   <title>{{ page.title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="{{ page.description | default: site.description }}">
+  <meta property="og:title" content="{{ page.title }}">
+  <meta property="og:description" content="{{ page.description | default: site.description }}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ page.url | absolute_url }}">
+  <meta property="og:image" content="{{ '/images/profile.png' | absolute_url }}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ page.title }}">
+  <meta name="twitter:description" content="{{ page.description | default: site.description }}">
+  <meta name="twitter:image" content="{{ '/images/profile.png' | absolute_url }}">
+  <link rel="canonical" href="{{ page.url | absolute_url }}">
   <link rel="stylesheet" href="/assets/css/terminal.css">
 </head>
 <body>

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -34,7 +34,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
   buttons.forEach(btn => {
     const cmd = btn.dataset.cmd;
-    const content = btn.dataset.content.split('\\n').join('\n\n').trim();
+    const key = btn.dataset.key;
+    const content = (profileData[key] || '').split('\n').join('\n\n').trim();
     commands[cmd] = content;
     btn.addEventListener('click', () => {
       runCommand(cmd, content);

--- a/index.md
+++ b/index.md
@@ -1,21 +1,22 @@
 ---
 layout: terminal
 title: "Robbie Rao Fenggui"
+description: "Interdisciplinary design researcher bridging art, technology, and human-centered innovation."
 ---
 
 <div class="container">
-  <img src="/images/profile.png" alt="Profile photo" class="profile">
+  <img src="/images/profile.png" alt="Profile photo" class="profile" loading="lazy" width="855" height="863">
   <h1>Robbie Rao Fenggui</h1>
   <p class="tagline">Interdisciplinary design researcher bridging art, technology, and human-centered innovation.</p>
   <div class="tags">
-    <button data-cmd="open contact" data-content="School of Design, PolyU\\nHung Hom, Kowloon, Hong Kong\\nSupervisor: Yan Tina Luximon\\nTel: (852) 84032765\\nEmail: robbie.rao@connect.polyu.hk">Contact</button>
-    <button data-cmd="open links" data-content="https://robbierao.com\\nhttps://sd.polyu.edu.hk/aedlab\\nhttps://designanything.design">Links</button>
-    <button data-cmd="open education" data-content="School of Design, The Hong Kong Polytechnic University – AED Lab, Ph.D. Student, 2024–Present.\\nChina Academy of Art – B.Eng in Innovative Design, 2020–2024.">Education</button>
-    <button data-cmd="open publications" data-content="The Immersive Art Therapy Driven by AIGC: An Innovative Approach to Alleviating Children’s Nyctophobia, CHI EA 2025.\\nBetween Real and Imagined: Developing a dynamic immersive virtual auditing (DIVA) framework for high-density urban health trails, eCAADe 2025.\\nContextCam: Bridging Context Awareness with Creative Human-AI Image Co-Creation, CHI 2024.\\nEnlivening Performance Art: Enhanced Interactivity through Embodied Cognition and Real-Time Physical Visualization on Swarm Tangible Interfaces, ICLC 2024.\\nTrailTracking: AI-Driven Distributed Narratives of Descendant Civilizations in a Digitally Encoded Cosmos, Science 24 hours 2024.">Publications</button>
-    <button data-cmd="open patents" data-content="AI-Assisted Design Creation Software – Software Monograph, 2023, Reg. No. 2023SR000001.\\nIntegrated Art Education Service Solution Based on Generative AI – Invention Patent, 2023, CN116000001A.\\nBox – Design Patent, 2022, CN305000001S.\\nA Kind of Robotic Arm – Utility Model Patent, 2022, CN216000001U.\\nImage Digital Projection Device – Utility Model Patent, 2022, CN216000002U.">Patents</button>
-    <button data-cmd="open award" data-content="AIGC-Driven Virtual Art Education Tutor – top honors.">Award</button>
-    <button data-cmd="open projects" data-content="Blind Box Experience Upgrade – Reimagined the blind box concept through innovative interaction design.\\nAIGC-Driven Virtual Art Education Tutor – Transformed virtual art education using generative AI.\\nPrivate Domain UX Design – Developed data-driven strategies and intuitive interfaces to enhance digital user engagement.">Projects</button>
-    <button data-cmd="open experience" data-content="CEO, Hangzhou BIZZLE Network Technology Co., Ltd. (Feb 2022 – Present).\\nCo-Founder, DesignAnything Lab, China Academy of Art (Mar 2022 – Sep 2024).">Experience</button>
+    <button data-cmd="open contact" data-key="contact">Contact</button>
+    <button data-cmd="open links" data-key="links">Links</button>
+    <button data-cmd="open education" data-key="education">Education</button>
+    <button data-cmd="open publications" data-key="publications">Publications</button>
+    <button data-cmd="open patents" data-key="patents">Patents</button>
+    <button data-cmd="open award" data-key="award">Award</button>
+    <button data-cmd="open projects" data-key="projects">Projects</button>
+    <button data-cmd="open experience" data-key="experience">Experience</button>
   </div>
   <div class="terminal-window">
     <div class="terminal-bar">
@@ -27,3 +28,6 @@ title: "Robbie Rao Fenggui"
     <input type="text" id="terminal-input" placeholder="Type a command...">
   </div>
 </div>
+<script>
+  const profileData = {{ site.data.profile | jsonify }};
+</script>


### PR DESCRIPTION
## Summary
- add SEO meta tags and dynamic locale to terminal layout
- move homepage terminal button text into a YAML data file and load via JS
- optimize profile image loading and enable Google Analytics

## Testing
- `npm run build:js`
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c6497656a8832e9ad024961cd77890