### PR TITLE
Refine terminal layout and interactions

### DIFF
--- a/_sass/layout/_sidebar.scss
+++ b/_sass/layout/_sidebar.scss
@@ -95,7 +95,9 @@
 
   img {
     max-width: 175px;
-    border-radius: 50%;
+    height: 175px;
+    object-fit: cover;
+    border-radius: 15px;
 
     @include breakpoint($large) {
       padding: 5px;

--- a/assets/css/terminal.css
+++ b/assets/css/terminal.css
@@ -8,9 +8,17 @@ body {
   margin: 2rem;
 }
 
+.container {
+  width: 95%;
+  max-width: 95%;
+  margin: 0 auto;
+}
+
 .profile {
   width: 150px;
-  border-radius: 50%;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 15px;
 }
 
 h1 {
@@ -20,7 +28,7 @@ h1 {
 
 .tagline {
   margin-bottom: 1rem;
-  text-align: center;
+  text-align: left;
 }
 
 .tags {
@@ -44,8 +52,9 @@ h1 {
 }
 
 .terminal-window {
-  width: 100%;
-  max-width: 600px;
+  width: 95%;
+  max-width: 95%;
+  margin: 0 auto;
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 0 10px rgba(0,0,0,0.25);
@@ -87,18 +96,6 @@ h1 {
   color: #fff;
 }
 
-#terminal-input {
-  width: 100%;
-  background: #000;
-  color: #0f0;
-  border: none;
-  padding: 0.5rem;
-  font-size: 0.9rem;
-  font-family: inherit;
-  box-sizing: border-box;
-  margin-top: 0.5rem;
-}
-
-#terminal-input:focus {
+#terminal .input {
   outline: none;
 }

--- a/index.md
+++ b/index.md
@@ -14,7 +14,6 @@ description: "Interdisciplinary design researcher bridging art, technology, and 
     <button data-cmd="open education" data-key="education">Education</button>
     <button data-cmd="open publications" data-key="publications">Publications</button>
     <button data-cmd="open patents" data-key="patents">Patents</button>
-    <button data-cmd="open award" data-key="award">Award</button>
     <button data-cmd="open projects" data-key="projects">Projects</button>
     <button data-cmd="open experience" data-key="experience">Experience</button>
   </div>
@@ -25,7 +24,6 @@ description: "Interdisciplinary design researcher bridging art, technology, and 
       <span class="dot green"></span>
     </div>
     <div id="terminal"></div>
-    <input type="text" id="terminal-input" placeholder="Type a command...">
   </div>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- Display profile photo as a rounded square and left-align intro text
- Resize terminal layout to center at 95% width and drop Award tag
- Replace input box with prompt-style entry and add `help`, `clear`, and `color` commands

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c64dafe498832eb1204c7930aa2ab1