### PR TITLE
Enhance terminal commands and styling

### DIFF
--- a/assets/css/terminal.css
+++ b/assets/css/terminal.css
@@ -12,6 +12,7 @@ body {
   width: 95%;
   max-width: 95%;
   margin: 0 auto;
+  text-align: center;
 }
 
 .profile {
@@ -28,7 +29,7 @@ h1 {
 
 .tagline {
   margin-bottom: 1rem;
-  text-align: left;
+  text-align: center;
 }
 
 .tags {
@@ -80,22 +81,19 @@ h1 {
 
 #terminal {
   background: #000;
-  color: #0f0;
+  color: #fff;
   padding: 1rem;
   font-size: 0.9rem;
-  min-height: 150px;
+  height: 300px;
+  overflow-y: auto;
   white-space: pre-wrap;
   line-height: 1.4;
 }
 
-#terminal .command {
-  color: #0f0;
-}
-
-#terminal .output {
-  color: #fff;
-}
-
 #terminal .input {
   outline: none;
+}
+
+#terminal .command {
+  color: #0f0;
 }

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -2,6 +2,14 @@ document.addEventListener('DOMContentLoaded', function () {
   const terminal = document.getElementById('terminal');
   const buttons = document.querySelectorAll('.tags button');
   const commands = {};
+  const builtInHandlers = {
+    ls: () => typeText('assets  images  scripts', printLine('')),
+    pwd: () => typeText('~', printLine('')),
+    date: () => typeText(new Date().toString(), printLine('')),
+    sudo: () => typeText('Nice try.', printLine('')),
+    'rm -rf /': () => typeText('Not that kind of terminal.', printLine('')),
+    dance: () => typeText('You found an easter egg!', printLine(''))
+  };
 
   function typeText(text, container) {
     let index = 0;
@@ -15,9 +23,10 @@ document.addEventListener('DOMContentLoaded', function () {
     type();
   }
 
-  function printLine(text) {
+  function printLine(text, className) {
     const line = document.createElement('div');
     line.textContent = text || '';
+    if (className) line.className = className;
     terminal.appendChild(line);
     terminal.scrollTop = terminal.scrollHeight;
     return line;
@@ -25,21 +34,25 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function processCommand(value) {
     const lower = value.toLowerCase();
-    if (lower === 'clear') {
-      terminal.innerHTML = '';
-      return;
-    }
-    if (lower.startsWith('color ')) {
-      const color = value.split(' ')[1];
-      terminal.style.color = color || '#0f0';
-      return;
-    }
-    if (lower === 'help') {
-      const builtIns = ['help', 'clear', 'color <color>'];
-      const list = builtIns.concat(Object.keys(commands));
-      typeText('Supported commands:\n' + list.join('\n'), printLine(''));
-      return;
-    }
+      if (lower === 'clear') {
+        terminal.innerHTML = '';
+        return;
+      }
+      if (lower.startsWith('color')) {
+        const color = value.split(' ')[1];
+        terminal.style.color = color || '#fff';
+        return;
+      }
+      if (lower === 'help') {
+        const builtIns = ['help', 'clear', 'color <color>', 'ls', 'pwd', 'date', 'sudo', 'rm -rf /', 'dance'];
+        const list = builtIns.concat(Object.keys(commands));
+        typeText('Supported commands:\n' + list.join('\n'), printLine(''));
+        return;
+      }
+      if (builtInHandlers[lower]) {
+        builtInHandlers[lower]();
+        return;
+      }
     if (commands[value]) {
       typeText(commands[value], printLine(''));
     } else {
@@ -49,7 +62,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function appendPrompt() {
     const line = document.createElement('div');
+    line.className = 'command';
     const prompt = document.createElement('span');
+    prompt.className = 'prompt';
     prompt.textContent = '> ';
     const input = document.createElement('span');
     input.className = 'input';
@@ -75,15 +90,17 @@ document.addEventListener('DOMContentLoaded', function () {
   buttons.forEach(btn => {
     const cmd = btn.dataset.cmd;
     const key = btn.dataset.key;
-    const content = (profileData[key] || '').split('\n').join('\n\n').trim();
-    commands[cmd] = content;
+    if (key) {
+      const content = (profileData[key] || '').split('\n').join('\n\n').trim();
+      commands[cmd] = content;
+    }
     btn.addEventListener('click', () => {
       const current = terminal.querySelector('.input[contenteditable="true"]');
       if (current) {
         current.textContent = cmd;
         current.contentEditable = false;
       } else {
-        printLine('> ' + cmd);
+        printLine('> ' + cmd, 'command');
       }
       processCommand(cmd);
       appendPrompt();

--- a/index.md
+++ b/index.md
@@ -16,6 +16,7 @@ description: "Interdisciplinary design researcher bridging art, technology, and 
     <button data-cmd="open patents" data-key="patents">Patents</button>
     <button data-cmd="open projects" data-key="projects">Projects</button>
     <button data-cmd="open experience" data-key="experience">Experience</button>
+    <button data-cmd="help">Help</button>
   </div>
   <div class="terminal-window">
     <div class="terminal-bar">


### PR DESCRIPTION
## Summary
- Highlight command prompts in green while leaving output white
- Center profile photo, name, and tagline on landing page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:js`
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c650e809a8832e9f035ad54f87f85d