### PR TITLE
Left-align terminal text on homepage

### DIFF
--- a/assets/css/terminal.css
+++ b/assets/css/terminal.css
@@ -88,6 +88,7 @@ h1 {
   overflow-y: auto;
   white-space: pre-wrap;
   line-height: 1.4;
+  text-align: left;
 }
 
 #terminal .input {


### PR DESCRIPTION
## Summary
- Ensure terminal component text is left-aligned

## Testing
- `bundle exec jekyll build` *(fails: jekyll command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c65bb0f418832ea0c5cf3b56a105e8