### PR TITLE
Clarify unknown command guidance in terminal

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -91,7 +91,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (commands[value]) {
       typeText(commands[value], printLine(''));
     } else {
-      typeText('Command not found', printLine(''));
+      typeText('Command not found. Please enter "help" to view available commands.', printLine(''));
     }
   }
 


### PR DESCRIPTION
## Summary
- Improve terminal feedback for unrecognized commands by prompting users to enter "help".

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:js`


------
https://chatgpt.com/codex/tasks/task_e_68c68b3a6c94832eb47da5cbcf9eac58